### PR TITLE
Builds on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,17 @@ LINK_FLAGS      += $(shell pkg-config --libs sdl2) -pthread
 
 ifeq ($(MACOS),true)
 BUILD_CXX_FLAGS += -D__MACOSX_CORE__
+# NOTE: If you have arm64/x86_64 mismatch linker problems, then 
+# try running: make clean; arch -x86_64 make
+# force x86_64 for JIT
+BUILD_CXX_FLAGS += -arch x86_64
+# reset LINK_FLAGS so we can ensure we don't pick up arm64 libs from /opt/
+LINK_FLAGS      = -arch x86_64
+LINK_FLAGS      += -L/usr/local/lib -lSDL2
 LINK_FLAGS      += -framework CoreMIDI
+LINK_FLAGS      += -framework OpenGL
+LINK_FLAGS      += -framework CoreFoundation
+LINK_FLAGS      += -framework CoreAudio
 else ifeq ($(WINDOWS),true)
 BUILD_CXX_FLAGS += -D__WINDOWS_MM__
 LINK_FLAGS      += -lwinmm

--- a/src/akwfdata.c
+++ b/src/akwfdata.c
@@ -1,0 +1,7 @@
+
+unsigned char akwfdata[10000];
+unsigned int akwfdata_size = sizeof(akwfdata);
+
+// TODO: Extract akwfdata from akwfdata.obj
+// TODO: Or... re-build it via akwfsorter.cpp
+

--- a/src/eval_impl_jit.cpp
+++ b/src/eval_impl_jit.cpp
@@ -1,3 +1,13 @@
+// eval_impl_jit.cpp
+
+#if defined(__APPLE__)
+// Avoid a name-conflict between our 'label' function and the
+// one defined in this header file.
+#define label IGNORE_LABEL
+#include <sys/ucred.h>
+#undef label
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
This PR allows Sassy to build and run on macOS, but sadly it crashes at runtime in the JIT-compiled `eval_all()` during audio callback.

I suspect this is the same issue mentioned in #1 on Linux.

Any clues about how to diagnose the problem?

Note that the macOS build settings in the Makefile are slightly odd given that I'm building on an M1 arm64 machine, but asking the compiler to build an x86_64 executable to run under Rosetta 2. In theory this should work, even with JIT code, as documented here: https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment but if someone has an Intel Mac to test on, it would be good to verify that this is/isn't related to the crash.